### PR TITLE
Feat: Add BTOP and Change Zellij Layout

### DIFF
--- a/home/imhotep/core/yazi.nix
+++ b/home/imhotep/core/yazi.nix
@@ -53,35 +53,47 @@
   home.file.".config/zellij/layouts/yazi.kdl".text = lib.mkIf
     config.programs.zellij.enable
     ''
-        layout {
-          tab_template name="ui" {
+      layout {
+          tab name="btop" hide_floating_panes=true {
               pane size=1 borderless=true {
-                 plugin location="zellij:tab-bar"
+                  plugin location="zellij:tab-bar"
               }
-              children
+              pane command="btop" {
+                  start_suspended false
+              }
               pane size=1 borderless=true {
-                 plugin location="zellij:status-bar"
+                  plugin location="zellij:status-bar"
               }
           }
-
-          default_tab_template {
+          tab name="localhost" focus=true {
               pane size=1 borderless=true {
-                 plugin location="zellij:tab-bar"
+                  plugin location="zellij:tab-bar"
+              }
+              pane name="sidebar" {
+                  command "env"
+                  args "YAZI_CONFIG_HOME=~/.config/yazi" "yazi"
+              }
+              pane size=1 borderless=true {
+                  plugin location="zellij:status-bar"
+              }
+          }
+          new_tab_template {
+              pane size=1 borderless=true {
+                  plugin location="zellij:tab-bar"
               }
               pane split_direction="vertical" {
-                  pane name="sidebar" {
-                      command "env"
+                  pane command="env" name="sidebar" size="100%" {
                       args "YAZI_CONFIG_HOME=~/.config/yazi/" "yazi"
-                  	size "100%"
+                      start_suspended true
                   }
               }
               pane size=1 borderless=true {
-                 plugin location="zellij:status-bar"
+                  plugin location="zellij:status-bar"
               }
-          }
-
-          floating_panes {
-            pane {}
+              floating_panes {
+                  pane {
+                  }
+              }
           }
       }
     '';

--- a/hosts/common/core/btop.nix
+++ b/hosts/common/core/btop.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.btop ];
+}


### PR DESCRIPTION
- Add btop to core packages
- For imhotep, update default zellij layout (in yazi.nix) to continue starting yazi by default, but also create a first tab running btop for system resource monitoring